### PR TITLE
Add MIT license page with site links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Ramon Roca
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Here are some ideas to get you started:
 - 😄 Pronouns: ...
 - ⚡ Fun fact: ...
 -->
+
+### License
+
+This project is licensed under the [MIT License](LICENSE).
+

--- a/src/pages/ca/index.astro
+++ b/src/pages/ca/index.astro
@@ -275,7 +275,10 @@ import ProteinVisualization from '../../components/ProteinVisualization.astro';
   <!-- Footer -->
   <footer class="footer">
     <div class="container">
-      <p>&copy; 2025 Ramon Roca Pinilla. Tots els drets reservats.</p>
+      <p>
+        &copy; 2025 Ramon Roca Pinilla. Publicat sota la
+        <a href="/Portfolio/license">Llicència MIT</a>.
+      </p>
     </div>
   </footer>
 </Layout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -275,7 +275,10 @@ import ProteinVisualization from '../../components/ProteinVisualization.astro';
   <!-- Footer -->
   <footer class="footer">
     <div class="container">
-      <p>&copy; 2025 Ramon Roca Pinilla. All rights reserved.</p>
+      <p>
+        &copy; 2025 Ramon Roca Pinilla. Released under the
+        <a href="/Portfolio/license">MIT License</a>.
+      </p>
     </div>
   </footer>
 </Layout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -275,7 +275,10 @@ import ProteinVisualization from '../../components/ProteinVisualization.astro';
   <!-- Footer -->
   <footer class="footer">
     <div class="container">
-      <p>&copy; 2025 Ramon Roca Pinilla. Todos los derechos reservados.</p>
+      <p>
+        &copy; 2025 Ramon Roca Pinilla. Licenciado bajo la
+        <a href="/Portfolio/license">Licencia MIT</a>.
+      </p>
     </div>
   </footer>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -276,7 +276,10 @@ import ProteinVisualization from '../components/ProteinVisualization.astro';
   <!-- Footer -->
   <footer class="footer">
     <div class="container">
-      <p>&copy; 2025 Ramon Roca Pinilla. All rights reserved.</p>
+      <p>
+        &copy; 2025 Ramon Roca Pinilla. Released under the
+        <a href="/Portfolio/license">MIT License</a>.
+      </p>
     </div>
   </footer>
 </Layout>

--- a/src/pages/license.astro
+++ b/src/pages/license.astro
@@ -1,0 +1,49 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navigation from '../components/Navigation.astro';
+---
+
+<Layout title="MIT License">
+  <Navigation />
+  <main class="license">
+    <div class="container">
+      <h1>MIT License</h1>
+      <pre>
+MIT License
+
+Copyright (c) 2024 Ramon Roca
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+      </pre>
+    </div>
+  </main>
+</Layout>
+
+<style>
+  .license {
+    padding: var(--space-lg) 0;
+  }
+
+  .license pre {
+    white-space: pre-wrap;
+    background: var(--background-alt);
+    padding: var(--space-sm);
+    border-radius: 4px;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add MIT license page for static site
- link to license from every page footer

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886512a92e4832c97b7af3435bf905c