### PR TITLE
feat: unify typography and tighten css build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
+
+      - name: Accessibility audit
+        run: |
+          npx pa11y dist/en/index.html
+          npx pa11y dist/es/index.html
+          npx pa11y dist/ca/index.html
           
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A bold, minimalistic portfolio showcasing biomedical engineering and molecular b
 
 - **Astro 4.14.2** - Static site generator
 - **Tailwind CSS v3** - Utility-first CSS framework  
-- **Inter Variable + Playfair Display** - Typography via @fontsource-variable
+- **Inter Variable** - Unified typography via Google Fonts
 - **React 18** - For interactive components (antibiotic timeline)
 - **TypeScript** - Type safety
 - **Sharp** - Image optimization
@@ -14,15 +14,17 @@ A bold, minimalistic portfolio showcasing biomedical engineering and molecular b
 ## 🎨 Design System
 
 ### Color Palette
-- **Primary Background**: `#2B0000` (Dark red)
-- **Surface**: `#400000` (Medium red)
-- **Accent Yellow**: `#FFD300` (High contrast)
-- **Body Text**: `#F3F3F3` (Light gray)
-- **Text Muted**: `#B8B8B8` (Medium gray)
+- **Primary Background**: `#000000`
+- **Surface 1**: `#111111`
+- **Surface 2**: `#181818`
+- **Accent Yellow**: `#FFD300`
+- **Accent Red**: `#D72638`
+- **Body Text**: `#F3F3F3`
+- **Text Muted**: `#B8B8B8`
 
 ### Typography
 - **Body**: Inter Variable (400-600 weight)
-- **Headings**: Playfair Display Variable (400-700 weight)
+- **Headings**: Inter Variable
 - **Max-width**: 1280px centered grid
 - **Line length**: 45-75 characters for optimal readability
 - **Text alignment**: Justified paragraphs
@@ -56,6 +58,9 @@ npm run dev
 
 # Build for production
 npm run build
+
+# Deploy to GitHub Pages (push to main triggers workflow)
+git push origin main
 
 # Preview production build
 npm run preview
@@ -130,7 +135,7 @@ Automated deployment via GitHub Actions to GitHub Pages:
 - **Responsive design** with mobile optimization
 
 ### Grid System
-- **12-column CSS Grid** for consistent layouts
+- **Responsive CSS Grid** using `repeat(auto-fit,minmax(320px,1fr))`
 - **Container max-width**: 1280px
 - **Responsive breakpoints** for mobile/tablet/desktop
 - **Flexible component spanning**

--- a/dist-sizes.json
+++ b/dist-sizes.json
@@ -1,10 +1,10 @@
 {
   "status": "success",
-  "timestamp": "2024-08-02T00:56:00Z",
+  "timestamp": "2025-08-03T13:24:35.921Z",
   "bundleSize": {
     "css": {
       "raw": "18.2kB",
-      "gzipped": "4.8kB"
+      "gzipped": "3.33kB"
     },
     "javascript": {
       "client": "135.61kB",
@@ -15,13 +15,16 @@
     },
     "images": {
       "optimized": true,
-      "formats": ["webp", "avif"],
+      "formats": [
+        "webp",
+        "avif"
+      ],
       "totalSavings": "60%"
     }
   },
   "performance": {
     "lcp": "1.2s",
-    "fid": "45ms", 
+    "fid": "45ms",
     "cls": "0.08",
     "ttfb": "0.3s"
   },

--- a/optimize-build.js
+++ b/optimize-build.js
@@ -1,53 +1,76 @@
 import { PurgeCSS } from 'purgecss';
 import { readFile, writeFile, readdir } from 'fs/promises';
 import { join } from 'path';
+import { gzipSync } from 'zlib';
 
-// Configure PurgeCSS for production optimization
 const purgeCSSConfig = {
   content: ['./dist/**/*.html', './dist/**/*.js'],
   css: ['./dist/**/*.css'],
-  safelist: {
-    standard: [/^astro-/, /^dark/, /^hover:/, /^focus:/, /^motion-/],
-    deep: [/animate-/],
-    greedy: [/transition/],
-  },
-  blocklist: [],
-  keyframes: true,
-  variables: true,
-  fontFace: true,
+  safelist: { standard: [/^astro-/], deep: [], greedy: [] },
 };
 
-async function optimizeBuild() {
+const baselineFile = './dist-sizes.json';
+
+function parseSize(input) {
+  return input.endsWith('kB') ? parseFloat(input) * 1024 : parseFloat(input);
+}
+
+function formatSize(bytes) {
+  return `${(bytes / 1024).toFixed(2)}kB`;
+}
+
+async function getFiles(dir, ext) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const res = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...await getFiles(res, ext));
+    else if (res.endsWith(ext)) files.push(res);
+  }
+  return files;
+}
+
+async function optimize() {
   console.log('🎯 Starting CSS optimization...');
-  
   try {
-    // Run PurgeCSS
-    const purgeCSSResults = await new PurgeCSS().purge(purgeCSSConfig);
-    
-    // Write optimized CSS files
-    for (const result of purgeCSSResults) {
-      if (result.file) {
-        await writeFile(result.file, result.css);
-        const originalSize = result.css.length;
-        const optimizedSize = result.css.length;
-        console.log(`✅ Optimized ${result.file}: ${originalSize} → ${optimizedSize} bytes`);
+    await new PurgeCSS().purge(purgeCSSConfig);
+
+    const cssFiles = await getFiles('./dist', '.css');
+    const htmlFiles = await getFiles('./dist', '.html');
+    let total = 0;
+    for (const file of cssFiles) {
+      const css = await readFile(file);
+      total += gzipSync(css).length;
+    }
+    for (const file of htmlFiles) {
+      const html = await readFile(file, 'utf8');
+      const matches = html.match(/<style[^>]*>([^<]*)<\/style>/g) || [];
+      for (const m of matches) {
+        const css = m.replace(/<style[^>]*>|<\/style>/g, '');
+        total += gzipSync(Buffer.from(css)).length;
       }
     }
-    
-    // Generate optimization report
-    const report = {
-      timestamp: new Date().toISOString(),
-      filesOptimized: purgeCSSResults.length,
-      totalSavings: purgeCSSResults.reduce((acc, r) => acc + (r.rejected?.length || 0), 0),
-    };
-    
+
+    const baseline = JSON.parse(await readFile(baselineFile, 'utf8'));
+    const previous = parseSize(baseline.bundleSize.css.gzipped);
+    const growth = ((total - previous) / previous) * 100;
+    if (growth > 10) {
+      console.error(`❌ CSS bundle grew by ${growth.toFixed(1)}%`);
+      process.exit(1);
+    }
+
+    baseline.bundleSize.css.gzipped = formatSize(total);
+    baseline.timestamp = new Date().toISOString();
+    await writeFile(baselineFile, JSON.stringify(baseline, null, 2));
+
+    const report = { timestamp: baseline.timestamp, cssGzipped: baseline.bundleSize.css.gzipped };
     await writeFile('./dist/optimization-report.json', JSON.stringify(report, null, 2));
-    console.log('📊 Optimization complete! Report saved to dist/optimization-report.json');
-    
-  } catch (error) {
-    console.error('❌ Optimization failed:', error);
+    console.log(`📊 CSS size: ${baseline.bundleSize.css.gzipped}`);
+    console.log('✅ Optimization complete');
+  } catch (err) {
+    console.error('❌ Optimization failed:', err);
     process.exit(1);
   }
 }
 
-optimizeBuild();
+optimize();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
         "@astrojs/react": "^3.6.2",
         "@astrojs/sitemap": "^3.1.6",
         "@astrojs/tailwind": "^5.1.0",
-        "@fontsource-variable/inter": "^5.2.6",
-        "@fontsource-variable/playfair-display": "^5.2.6",
         "astro": "^4.14.2",
         "d3": "^7.9.0",
         "react": "^18.3.1",
@@ -1182,24 +1180,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fontsource-variable/inter": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.6.tgz",
-      "integrity": "sha512-jks/bficUPQ9nn7GvXvHtlQIPudW7Wx8CrlZoY8bhxgeobNxlQan8DclUJuYF2loYRrGpfrhCIZZspXYysiVGg==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource-variable/playfair-display": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/playfair-display/-/playfair-display-5.2.6.tgz",
-      "integrity": "sha512-Uedpo4WwsWtobi1KMYGm9tlKcZJcD18EiBtPWhbbccT2u58qM7vwkOZGdrmdWVDhcEhjwNrqRUyZijwIFtsCcQ==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "astro build && node optimize-build.js",
     "preview": "astro preview",
     "astro": "astro",
     "lint": "eslint src",
@@ -17,8 +17,6 @@
     "@astrojs/react": "^3.6.2",
     "@astrojs/sitemap": "^3.1.6",
     "@astrojs/tailwind": "^5.1.0",
-    "@fontsource-variable/inter": "^5.2.6",
-    "@fontsource-variable/playfair-display": "^5.2.6",
     "astro": "^4.14.2",
     "d3": "^7.9.0",
     "react": "^18.3.1",

--- a/src/components/BaseLayout.astro
+++ b/src/components/BaseLayout.astro
@@ -1,6 +1,4 @@
 ---
-import '@fontsource-variable/inter';
-import '@fontsource-variable/playfair-display';
 import '../styles/global.css';
 
 export interface Props {
@@ -40,9 +38,11 @@ const langMeta = {
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
     
-    <!-- Preload critical fonts -->
-    <link rel="preload" href="/fonts/inter-variable.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="preload" href="/fonts/playfair-display-variable.woff2" as="font" type="font/woff2" crossorigin />
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" as="style" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
     
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
@@ -76,8 +76,8 @@ const langMeta = {
         <slot name="header" />
       </header>
       
-      <main id="main-content" class="container-12">
-        <div class="grid-12">
+      <main id="main-content" class="px-4">
+        <div class="mx-auto max-w-screen-lg grid gap-8 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
           <slot />
         </div>
       </main>

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -7,7 +7,7 @@ export interface Props {
 const { lang, strings } = Astro.props;
 ---
 
-<section id="contact" class="col-span-12 py-24 bg-surface-1">
+<section id="contact" class="col-span-full py-24 bg-surface-1">
   <div class="max-w-4xl mx-auto text-center">
     <h2 class="font-heading text-display-md mb-8 text-balance">
       {strings.contact.title}

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -9,7 +9,7 @@ export interface Props {
 const { lang, strings } = Astro.props;
 ---
 
-<section class="col-span-12 min-h-screen flex items-center justify-center text-center py-20">
+<section class="col-span-full min-h-screen flex items-center justify-center text-center py-20">
   <div class="max-w-4xl px-4">
     <h1 class="font-heading text-display-lg lg:text-display-xl text-balance mb-6 text-body-text">
       {strings.hero.name}

--- a/src/components/Publications.astro
+++ b/src/components/Publications.astro
@@ -26,7 +26,7 @@ const publications = [
 ];
 ---
 
-<section id="publications" class="col-span-12 py-24">
+<section id="publications" class="col-span-full py-24">
   <div class="max-w-4xl mx-auto">
     <h2 class="font-heading text-display-md text-center mb-16 text-balance">
       {strings.publications.title}

--- a/src/components/Research.astro
+++ b/src/components/Research.astro
@@ -9,7 +9,7 @@ export interface Props {
 const { lang, strings } = Astro.props;
 ---
 
-<section id="research" class="col-span-12 py-24">
+<section id="research" class="col-span-full py-24">
   <div class="max-w-4xl mx-auto">
     <h2 class="font-heading text-display-md text-center mb-16 text-balance">
       {strings.research.title}

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -24,7 +24,7 @@ const timelineData = [
 ];
 ---
 
-<section id="timeline" class="col-span-12 py-24 bg-surface-1">
+<section id="timeline" class="col-span-full py-24 bg-surface-1">
   <div class="max-w-4xl mx-auto">
     <h2 class="font-heading text-display-md text-center mb-16 text-balance">
       {strings.timeline.title}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,20 +2,7 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
-/* Critical font loading with font-display: swap */
-@import '@fontsource-variable/inter/wght.css';
-@import '@fontsource-variable/playfair-display/wght.css';
-
-/* Explicit font-display declarations */
-@font-face {
-  font-family: 'Inter Variable';
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Playfair Display Variable';
-  font-display: swap;
-}
+/* Fonts loaded via Google Fonts with font-display swap */
 
 /* Base styles */
 @layer base {
@@ -93,7 +80,7 @@
   }
   
   .btn-primary:hover {
-    background-color: #e6be00;
+    filter: brightness(1.1);
   }
   
   .btn-secondary {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,26 +3,24 @@ export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
     colors: {
-      // Design System - Bold Dark Red Palette
-      'primary-bg': '#2B0000',
-      'surface-1': '#400000', 
-      'surface-2': '#600000',
+      'primary-bg': '#000000',
+      'surface-1': '#111111',
+      'surface-2': '#181818',
       'accent-yellow': '#FFD300',
+      'accent-red': '#D72638',
       'on-accent-text': '#000000',
       'body-text': '#F3F3F3',
       'text-muted': '#B8B8B8',
-      'border': '#600000',
-      // System colors
-      'white': '#ffffff',
-      'black': '#000000',
-      'transparent': 'transparent',
-      'current': 'currentColor',
+      'border': '#181818',
+      white: '#ffffff',
+      black: '#000000',
+      transparent: 'transparent',
+      current: 'currentColor',
     },
     fontFamily: {
       body: ['Inter Variable', 'Inter', 'system-ui', 'sans-serif'],
-      heading: ['Playfair Display Variable', 'Playfair Display', 'serif'],
+      heading: ['Inter Variable', 'Inter', 'system-ui', 'sans-serif'],
       sans: ['Inter Variable', 'Inter', 'system-ui', 'sans-serif'],
-      serif: ['Playfair Display Variable', 'Playfair Display', 'serif'],
     },
     fontSize: {
       'display-xl': ['4.5rem', { lineHeight: '1.1', letterSpacing: '-0.02em' }],


### PR DESCRIPTION
## Summary
- run CSS optimization and size regression check during build
- switch to Inter variable font and centralize dark palette tokens
- simplify section layout with shared responsive grid

## Testing
- `npm run build`
- `npx -y pa11y dist/en/index.html` *(fails: libXcomposite.so.1 missing)*
- `npm run lint` *(fails: Parsing error: The keyword 'interface' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_688f610b66b8832caf2a2663689ae8a0